### PR TITLE
Added ability to use picodi dependencies in FastAPI views without nee…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ We follow [Semantic Versions](https://semver.org/).
 
 ## Version next
 
+## Version 0.30.0
+
+- Now you can use picodi dependencies in FastAPI views without need to
+  decorate view with `@inject`.
+
 ## Version 0.29.0
 
 - Support for Python 3.13

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -85,14 +85,22 @@ you can use ``Depends`` with :func:`picodi.integrations.fastapi.Provide`.
     # curl http://localhost:8000/
     # Output: {"redis":"http://redis:8080"}
 
+Injecting dependencies in FastAPI views without ``@inject``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 ``Depends(Provide(...))`` looks a bit verbose, if you want to make it shorter,
 you can use a ``wrap`` parameter of :func:`picodi.integrations.fastapi.Provide`.
+
+Also because FastAPI already has mechanism of resolving dependencies, we can use it
+without need to use ``@inject`` decorator, just pass ``wrap=True``
+to :func:`picodi.integrations.fastapi.Provide`. This is preferred way to use Picodi
+dependencies in FastAPI views.
 
 .. testcode::
 
     @app.get("/")
-    @inject
-    async def read_root(redis: str = Provide(get_redis_connection, wrap=True)): ...
+    async def read_root(redis: str = Provide(get_redis_connection, wrap=True)):
+        pass
 
 Combining Picodi with FastAPI dependency injection system
 *********************************************************
@@ -205,7 +213,8 @@ Like with Starlette you can use request scope in FastAPI application.
     # Dependencies will be initialized once per request
     #   and closed after the request is finished.
     @dependency(scope_class=RequestScope)
-    def get_cache(): ...
+    def get_cache():
+        pass
 
 Example FastAPI application with Picodi
 ****************************************
@@ -214,3 +223,8 @@ Here is an more complex example of a FastAPI application
 that uses Picodi for dependency injection:
 
 `Picodi FastAPI Example <https://github.com/yakimka/picodi-fastapi-example>`_
+
+Pytest
+------
+
+About ``pytest`` integration you can read at :doc:`testing`

--- a/docs/overriding.rst
+++ b/docs/overriding.rst
@@ -13,7 +13,8 @@ for implementing "abstract" dependencies.
 
     # Dependency that return app settings
     #   usually it should be implemented in the app
-    def get_settings(): ...
+    def get_settings():
+        pass
 
 
     def get_test_settings():
@@ -33,7 +34,8 @@ You can also use :func:`picodi.registry.override` as a regular method call.
     from picodi import registry
 
 
-    def get_settings() -> dict: ...
+    def get_settings() -> dict:
+        pass
 
 
     def get_test_setting():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "picodi"
 description = "Simple Dependency Injection for Python"
-version = "0.29.0"
+version = "0.30.0"
 license = "MIT"
 authors = [
   "yakimka"


### PR DESCRIPTION
…d to

  decorate view with `@inject`.